### PR TITLE
fix a stray rendered semicolon

### DIFF
--- a/src/components/song.js
+++ b/src/components/song.js
@@ -277,7 +277,7 @@ export default class Song extends Component {
           width={800}
           height={512}
           ref={(c) => { this.canvas = c; }}
-        />;
+        />
         <button
           className="react-music-button"
           type="button"


### PR DESCRIPTION
There was a semicolon that was being rendered between the canvas and the button.
