### PR TITLE
Adjusts beatInterval to produce the correct tempo value

### DIFF
--- a/demo/index.js
+++ b/demo/index.js
@@ -3,7 +3,7 @@ import ReactDOM from 'react-dom';
 import { Song, Sequencer, Sampler, Synth } from '../src';
 
 ReactDOM.render(
-  <Song tempo={190}>
+  <Song tempo={95}>
     <Sequencer resolution={16} bars={2}>
       <Sampler
         sample="samples/kick.wav"

--- a/src/components/song.js
+++ b/src/components/song.js
@@ -33,7 +33,7 @@ export default class Song extends Component {
 
     const { tempo, children: seqChildren } = this.props;
 
-    const beatInterval = 60000 / tempo;
+    const beatInterval = 30000 / tempo;
 
     this.barInterval = beatInterval * 4;
 


### PR DESCRIPTION
Currently, demo song has a tempo of 190 which translates into an actual 95 BPM. This PR amends this by changing the value of `beatInterval` in the `Song` component.
