### PR TITLE
Close audio context when unmounting Song component

### DIFF
--- a/src/components/song.js
+++ b/src/components/song.js
@@ -61,6 +61,9 @@ export default class Song extends Component {
 
     this.init();
   }
+  componentWillUnmount() {
+    this.context.close();
+  }
   setupVisualization() {
     this.visualization = this.context.createScriptProcessor(2048, 1, 1);
     this.visualization.connect(this.context.destination);


### PR DESCRIPTION
This fixes a leak that would have otherwise prevented you from mounting
and unmounting Song more than a few times, since the browser will error
out saying that there is no audio context available.

See also https://developer.mozilla.org/en-US/docs/Web/API/AudioContext/close
