### PR TITLE
Make the flow/prop types for Synth and Filter type more granular

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -58,7 +58,6 @@ export default class Demo extends Component {
               bars={2}
             >
               <Polysynth
-                type="sine"
                 steps={[
                   [0, 1, ['c3', 'd#3', 'g3' ]],
                   [2, 1, ['c4']],

--- a/src/components/filter.js
+++ b/src/components/filter.js
@@ -2,11 +2,21 @@
 /* eslint-disable no-restricted-syntax */
 import React, { PropTypes, Component } from 'react';
 
+type BiquadFilterType =
+  'lowpass' |
+  'highpass' |
+  'bandpass' |
+  'lowshelf' |
+  'highshelf' |
+  'peaking' |
+  'notch' |
+  'allpass';
+
 type Props = {
   children?: any;
   frequency?: number;
   gain?: number;
-  type?: string;
+  type?: BiquadFilterType;
 };
 
 type Context = {
@@ -23,7 +33,16 @@ export default class Filter extends Component {
     children: PropTypes.node,
     frequency: PropTypes.number,
     gain: PropTypes.number,
-    type: PropTypes.string,
+    type: PropTypes.oneOf([
+      'lowpass',
+      'highpass',
+      'bandpass',
+      'lowshelf',
+      'highshelf',
+      'peaking',
+      'notch',
+      'allpass',
+    ]),
   };
   static defaultProps = {
     frequency: 2000,

--- a/src/components/synth.js
+++ b/src/components/synth.js
@@ -12,6 +12,8 @@ type Envelope = {
   release?: number;
 };
 
+type OscillatorType = 'sine' | 'square' | 'sawtooth' | 'triangle';
+
 type Props = {
   busses: Array<string>;
   children: any;
@@ -19,7 +21,7 @@ type Props = {
   gain?: number;
   steps: Array<any>;
   transpose?: number;
-  type: string;
+  type: OscillatorType;
 };
 
 type Context = {
@@ -53,7 +55,7 @@ export default class Synth extends Component {
     gain: PropTypes.number,
     steps: PropTypes.array.isRequired,
     transpose: PropTypes.number,
-    type: PropTypes.string.isRequired,
+    type: PropTypes.oneOf(['sine', 'square', 'sawtooth', 'triangle']).isRequired,
   };
   static defaultProps = {
     envelope: {
@@ -185,4 +187,3 @@ export default class Synth extends Component {
     return <span>{this.props.children}</span>;
   }
 }
-


### PR DESCRIPTION
react-music is awesome 💥 

I found myself looking at the flow types of props to see what values I can use, so I added typings for the `type` prop of `Synth` and `Filter` to make them more self-documenting.

I searched the Web Audio API spec for `enum`, and I think all enums currently used from there are now typed 😄 
