### PR TITLE
Take Hot Reloading off of the Roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,7 +479,6 @@ steps={[
 ## Known Issues & Roadmap
 
 - Currently only the 4/4 time signature is supported
-- Hot reloading doesn't work
 - `Synth` presets need to be added
 - Record/Ouput audio file
 - Optional working mixing board alongside viz

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 ## TODO
 
 - Add Tests
-- Add Hot Reload
 - Update Docs


### PR DESCRIPTION
Per this [this commit](https://github.com/FormidableLabs/react-music/commit/93eb48db10fa20fb759b645361a93ea9c4474116), it seems that the hot reloading feature has been stably added to the repo and no longer needs to be a "todo" feature.