### PR TITLE
SMALL FIX: Remove white bar at the bottom of dark mode

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -35,7 +35,6 @@ export default class Demo extends Component {
     });
   }
   toggleLightMode(){
-    console.log('toggled');
     this.setState({lightMode: !this.state.lightMode});
   }
   render() {

--- a/public/index.css
+++ b/public/index.css
@@ -4,3 +4,7 @@ html, body {
   margin: 0;
   padding: 0;
 }
+
+#root {
+  height: 100%;
+}


### PR DESCRIPTION
There's a small strip of white at the bottom of the screen when in dark mode. 

This commit fixes that by making the height of the root div the height of the entire window.